### PR TITLE
Add Missing ')'

### DIFF
--- a/MarkupGatewayPlugin.inc.php
+++ b/MarkupGatewayPlugin.inc.php
@@ -275,7 +275,7 @@ class MarkupGatewayPlugin extends GatewayPlugin {
 				'contributors'      => $authors,
 				'ISSN'              => $journal->getSetting('onlineIssn'),
 				'journal-id'        => $journal->getId(),
-				'year'              => date('Y', strtotime($publishedArticle->getDatePublished())
+				'year'              => date('Y', strtotime($publishedArticle->getDatePublished()))
 		);
 	}
 	


### PR DESCRIPTION
I was not able to upgrade my ojs3 version because of this:

```
$ php tools/upgrade.php upgrade
PHP Parse error:  syntax error, unexpected ';', expecting ')' in /srv/www/ojs-3.0.2/plugins/generic/markup/MarkupGatewayPlugin.inc.php on line 279

Parse error: syntax error, unexpected ';', expecting ')' in /srv/www/ojs-3.0.2/plugins/generic/markup/MarkupGatewayPlugin.inc.php on line 279
```